### PR TITLE
VRCSDKなしでもManual bake avatarが押せるようにする Ver. ndmf + MA1.8.0 + AAO1.5.1

### DIFF
--- a/Editor/ActiveAnimationRetargeter.cs
+++ b/Editor/ActiveAnimationRetargeter.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using nadena.dev.modular_avatar.animation;
 using UnityEditor;
 using UnityEngine;
-using VRC.SDK3.Avatars.Components;
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -57,7 +56,7 @@ namespace nadena.dev.modular_avatar.core.editor
             _boneDatabase = boneDatabase;
             _pathMappings = context.PluginBuildContext.Extension<AnimationServicesContext>().PathMappings;
 
-            while (root != null && root.GetComponent<VRCAvatarDescriptor>() == null)
+            while (root != null && RuntimeUtil.IsAvatarRoot(root))
             {
                 var originalPath = RuntimeUtil.AvatarRootPath(root.gameObject);
                 System.Diagnostics.Debug.Assert(originalPath != null);

--- a/Editor/Animation/AnimationDatabase.cs
+++ b/Editor/Animation/AnimationDatabase.cs
@@ -7,7 +7,11 @@ using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
+#endif
+
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.animation
@@ -110,6 +114,7 @@ namespace nadena.dev.modular_avatar.animation
 
             AnimationUtil.CloneAllControllers(context);
 
+#if MA_VRCSDK3_AVATARS
             var avatarDescriptor = context.AvatarDescriptor;
 
             foreach (var layer in avatarDescriptor.baseAnimationLayers)
@@ -136,6 +141,7 @@ namespace nadena.dev.modular_avatar.animation
                     });
                 }
             }
+#endif
         }
 
         /// <summary>

--- a/Editor/Animation/AnimationDatabase.cs
+++ b/Editor/Animation/AnimationDatabase.cs
@@ -112,9 +112,9 @@ namespace nadena.dev.modular_avatar.animation
         {
             _context = context;
 
+#if MA_VRCSDK3_AVATARS
             AnimationUtil.CloneAllControllers(context);
 
-#if MA_VRCSDK3_AVATARS
             var avatarDescriptor = context.AvatarDescriptor;
 
             foreach (var layer in avatarDescriptor.baseAnimationLayers)

--- a/Editor/Animation/AnimationUtil.cs
+++ b/Editor/Animation/AnimationUtil.cs
@@ -6,7 +6,10 @@ using nadena.dev.ndmf;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
+#endif
 
 #endregion
 
@@ -14,13 +17,14 @@ namespace nadena.dev.modular_avatar.animation
 {
     internal static class AnimationUtil
     {
+#if MA_VRCSDK3_AVATARS
         private const string SAMPLE_PATH_PACKAGE =
             "Packages/com.vrchat.avatars/Samples/AV3 Demo Assets/Animation/Controllers";
 
         private const string SAMPLE_PATH_LEGACY = "Assets/VRCSDK/Examples3/Animation/Controllers";
 
         private const string GUID_GESTURE_HANDSONLY_MASK = "b2b8bad9583e56a46a3e21795e96ad92";
-
+#endif
 
         public static AnimatorController DeepCloneAnimator(BuildContext context, RuntimeAnimatorController controller)
         {
@@ -42,6 +46,7 @@ namespace nadena.dev.modular_avatar.animation
             return merger.Finish();
         }
 
+#if MA_VRCSDK3_AVATARS
         internal static void CloneAllControllers(BuildContext context)
         {
             // Ensure all of the controllers on the avatar descriptor point to temporary assets.
@@ -214,5 +219,7 @@ namespace nadena.dev.modular_avatar.animation
                 }
             }
         }
+#endif
     }
 }
+

--- a/Editor/Animation/AnimatorCombiner.cs
+++ b/Editor/Animation/AnimatorCombiner.cs
@@ -31,7 +31,11 @@ using nadena.dev.modular_avatar.core.editor;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
+#endif
+
 using Object = UnityEngine.Object;
 
 #endregion
@@ -275,6 +279,7 @@ namespace nadena.dev.modular_avatar.animation
 
         private void AdjustBehavior(StateMachineBehaviour behavior)
         {
+#if MA_VRCSDK3_AVATARS
             switch (behavior)
             {
                 case VRCAnimatorLayerControl layerControl:
@@ -285,6 +290,7 @@ namespace nadena.dev.modular_avatar.animation
                     break;
                 }
             }
+#endif
         }
 
         private static string MapPath(EditorCurveBinding binding, string basePath)
@@ -309,7 +315,11 @@ namespace nadena.dev.modular_avatar.animation
         {
             if (o is AnimationClip clip)
             {
-                if (basePath == "" || clip.IsProxyAnimation()) return clip;
+                if (basePath == "") return clip;
+
+#if MA_VRCSDK3_AVATARS
+                if (clip.IsProxyAnimation()) return clip;
+#endif
 
                 AnimationClip newClip = new AnimationClip();
                 newClip.name = clip.name;

--- a/Editor/Animation/PathMappings.cs
+++ b/Editor/Animation/PathMappings.cs
@@ -7,6 +7,11 @@ using nadena.dev.ndmf;
 using nadena.dev.ndmf.util;
 using UnityEditor;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
+using VRC.SDK3.Avatars.Components;
+#endif
+
 using Object = UnityEngine.Object;
 
 #endregion
@@ -213,7 +218,9 @@ namespace nadena.dev.modular_avatar.animation
             if (originalClip == null) return null;
             if (clipCache != null && clipCache.TryGetValue(originalClip, out var cachedClip)) return cachedClip;
 
+#if MA_VRCSDK3_AVATARS
             if (originalClip.IsProxyAnimation()) return originalClip;
+#endif
 
             var curveBindings = AnimationUtility.GetCurveBindings(originalClip);
             var objectBindings = AnimationUtility.GetObjectReferenceCurveBindings(originalClip);

--- a/Editor/AnimatorMerger.cs
+++ b/Editor/AnimatorMerger.cs
@@ -29,7 +29,11 @@ using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
+#endif
+
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -254,6 +258,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
         private void AdjustBehavior(StateMachineBehaviour behavior)
         {
+#if MA_VRCSDK3_AVATARS
             switch (behavior)
             {
                 case VRCAnimatorLayerControl layerControl:
@@ -264,6 +269,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     break;
                 }
             }
+#endif
         }
 
         private static string MapPath(EditorCurveBinding binding, string basePath)

--- a/Editor/BlendshapeSyncAnimationProcessor.cs
+++ b/Editor/BlendshapeSyncAnimationProcessor.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System.Collections.Generic;
 using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEditor.Animations;
@@ -227,3 +229,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/BuildContext.cs
+++ b/Editor/BuildContext.cs
@@ -4,8 +4,12 @@ using nadena.dev.modular_avatar.animation;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
+#endif
+
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -14,24 +18,27 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         internal readonly nadena.dev.ndmf.BuildContext PluginBuildContext;
 
+#if MA_VRCSDK3_AVATARS
         internal VRCAvatarDescriptor AvatarDescriptor => PluginBuildContext.AvatarDescriptor;
 
+#endif
         internal AnimationDatabase AnimationDatabase =>
             PluginBuildContext.Extension<AnimationServicesContext>().AnimationDatabase;
 
         internal PathMappings PathMappings =>
             PluginBuildContext.Extension<AnimationServicesContext>().PathMappings;
-
         internal UnityEngine.Object AssetContainer => PluginBuildContext.AssetContainer;
 
         private bool SaveImmediate = false;
 
+#if MA_VRCSDK3_AVATARS
         internal readonly Dictionary<VRCExpressionsMenu, VRCExpressionsMenu> ClonedMenus
             = new Dictionary<VRCExpressionsMenu, VRCExpressionsMenu>();
-
+#endif
         public static implicit operator BuildContext(ndmf.BuildContext ctx) =>
             ctx.Extension<ModularAvatarContext>().BuildContext;
-
+        
+#if MA_VRCSDK3_AVATARS
         /// <summary>
         /// This dictionary overrides the _original contents_ of ModularAvatarMenuInstallers. Notably, this does not
         /// replace the source menu for the purposes of identifying any other MAMIs that might install to the same
@@ -39,16 +46,19 @@ namespace nadena.dev.modular_avatar.core.editor
         /// </summary>
         internal readonly Dictionary<ModularAvatarMenuInstaller, Action<VRCExpressionsMenu.Control>> PostProcessControls
             = new Dictionary<ModularAvatarMenuInstaller, Action<VRCExpressionsMenu.Control>>();
+#endif
 
         public BuildContext(nadena.dev.ndmf.BuildContext PluginBuildContext)
         {
             this.PluginBuildContext = PluginBuildContext;
         }
 
+#if MA_VRCSDK3_AVATARS
         public BuildContext(VRCAvatarDescriptor avatarDescriptor)
             : this(new ndmf.BuildContext(avatarDescriptor, null))
         {
         }
+#endif
 
         public void SaveAsset(Object obj)
         {
@@ -101,6 +111,7 @@ namespace nadena.dev.modular_avatar.core.editor
             return merger.Finish();
         }
 
+#if MA_VRCSDK3_AVATARS
         public VRCExpressionsMenu CloneMenu(VRCExpressionsMenu menu)
         {
             if (menu == null) return null;
@@ -119,5 +130,6 @@ namespace nadena.dev.modular_avatar.core.editor
 
             return newMenu;
         }
+#endif
     }
 }

--- a/Editor/BuildContext.cs
+++ b/Editor/BuildContext.cs
@@ -18,6 +18,8 @@ namespace nadena.dev.modular_avatar.core.editor
     {
         internal readonly nadena.dev.ndmf.BuildContext PluginBuildContext;
 
+        internal GameObject AvatarRootObject => PluginBuildContext.AvatarRootObject;
+        internal Transform AvatarRootTransform => PluginBuildContext.AvatarRootTransform;
 #if MA_VRCSDK3_AVATARS
         internal VRCAvatarDescriptor AvatarDescriptor => PluginBuildContext.AvatarDescriptor;
 

--- a/Editor/EasySetupOutfit.cs
+++ b/Editor/EasySetupOutfit.cs
@@ -280,16 +280,16 @@ namespace nadena.dev.modular_avatar.core.editor
                 // descriptors when transplanting outfits. Block this (and require that there be only one avdesc) by
                 // refusing to run if we detect multiple avatar descriptors above the current object (or if we're run on
                 // the avdesc object itself)
-                var nearestAvatar = RuntimeUtil.FindAvatarInParents(xform);
-                if (nearestAvatar == null || nearestAvatar.transform == xform)
+                var nearestAvatarTransform = RuntimeUtil.FindAvatarTransformInParents(xform);
+                if (nearestAvatarTransform == null || nearestAvatarTransform.transform == xform)
                 {
                     errorMessageGroups = new string[]
                         {S_f("setup_outfit.err.multiple_avatar_descriptors", xform.gameObject.name)};
                     return false;
                 }
 
-                var parent = nearestAvatar.transform.parent;
-                if (parent != null && RuntimeUtil.FindAvatarInParents(parent) != null)
+                var parent = nearestAvatarTransform.transform.parent;
+                if (parent != null && RuntimeUtil.FindAvatarTransformInParents(parent) != null)
                 {
                     errorMessageGroups = new string[]
                     {
@@ -308,7 +308,7 @@ namespace nadena.dev.modular_avatar.core.editor
             avatarHips = outfitHips = null;
             var outfitRoot = obj as GameObject;
             avatarRoot = outfitRoot != null
-                ? RuntimeUtil.FindAvatarInParents(outfitRoot.transform)?.gameObject
+                ? RuntimeUtil.FindAvatarTransformInParents(outfitRoot.transform)?.gameObject
                 : null;
 
             if (avatarRoot == null)

--- a/Editor/ErrorReporting/ErrorLog.cs
+++ b/Editor/ErrorReporting/ErrorLog.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using nadena.dev.modular_avatar.core;
 using Newtonsoft.Json;
 using UnityEngine;
-using VRC.SDK3.Avatars.Components;
 using UnityEditor;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
@@ -273,17 +272,17 @@ namespace nadena.dev.modular_avatar.editor.ErrorReporting
             }
         }
 
-        internal IDisposable ReportingOnAvatar(VRCAvatarDescriptor descriptor)
+        internal IDisposable ReportingOnAvatar(ndmf.BuildContext context)
         {
-            if (descriptor != null)
+            if (context != null)
             {
                 AvatarReport report = new AvatarReport();
-                report.objectRef = new ObjectRef(descriptor.gameObject);
+                report.objectRef = new ObjectRef(context.AvatarRootObject);
                 Avatars.Add(report);
                 _currentAvatar = report;
                 _currentAvatar.successful = true;
 
-                _currentAvatar.logs.AddRange(ComponentValidation.ValidateAll(descriptor.gameObject));
+                _currentAvatar.logs.AddRange(ComponentValidation.ValidateAll(context.AvatarRootObject));
             }
 
             return new AvatarReportScope();

--- a/Editor/ErrorReporting/ErrorReportUI.cs
+++ b/Editor/ErrorReporting/ErrorReportUI.cs
@@ -110,7 +110,7 @@ namespace nadena.dev.modular_avatar.editor.ErrorReporting
             GameObject activeAvatarObject = null;
             if (Selection.gameObjects.Length == 1)
             {
-                activeAvatarObject = RuntimeUtil.FindAvatarInParents(Selection.activeGameObject.transform)?.gameObject;
+                activeAvatarObject = RuntimeUtil.FindAvatarTransformInParents(Selection.activeGameObject.transform)?.gameObject;
                 activeAvatar = BuildReport.CurrentReport.Avatars.FirstOrDefault(av =>
                     av.objectRef.path == RuntimeUtil.RelativePath(null, activeAvatarObject)
                     || av.objectRef.path == RuntimeUtil.RelativePath(null, activeAvatarObject) + "(Clone)");

--- a/Editor/FixupPasses/FixupExpressionsMenuPass.cs
+++ b/Editor/FixupPasses/FixupExpressionsMenuPass.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -158,3 +160,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/HeuristicBoneMapper.cs
+++ b/Editor/HeuristicBoneMapper.cs
@@ -356,7 +356,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
         internal static void RenameBonesByHeuristic(ModularAvatarMergeArmature config)
         {
-            var target = config.mergeTarget.Get(RuntimeUtil.FindAvatarInParents(config.transform));
+            var target = config.mergeTarget.Get(RuntimeUtil.FindAvatarTransformInParents(config.transform));
             if (target == null) return;
 
             Traverse(config.transform, target.transform);

--- a/Editor/Inspector/AvatarObjectReferenceDrawer.cs
+++ b/Editor/Inspector/AvatarObjectReferenceDrawer.cs
@@ -134,7 +134,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 if (obj == null) return null;
 
                 var transform = obj.transform;
-                var avatar = RuntimeUtil.FindAvatarInParents(transform).transform;
+                var avatar = RuntimeUtil.FindAvatarTransformInParents(transform);
 
                 if (i == 0)
                 {

--- a/Editor/Inspector/AvatarObjectReferenceDrawer.cs
+++ b/Editor/Inspector/AvatarObjectReferenceDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEditor;
 using UnityEngine;
-using VRC.SDK3.Avatars.Components;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
@@ -122,12 +121,12 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
-        private static VRCAvatarDescriptor findContainingAvatar(SerializedProperty property)
+        private static Transform findContainingAvatar(SerializedProperty property)
         {
             // Find containing object, and from that the avatar
             if (property.serializedObject == null) return null;
 
-            VRCAvatarDescriptor commonAvatar = null;
+            Transform commonAvatar = null;
             var targets = property.serializedObject.targetObjects;
             for (int i = 0; i < targets.Length; i++)
             {
@@ -135,7 +134,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 if (obj == null) return null;
 
                 var transform = obj.transform;
-                var avatar = RuntimeUtil.FindAvatarInParents(transform);
+                var avatar = RuntimeUtil.FindAvatarInParents(transform).transform;
 
                 if (i == 0)
                 {

--- a/Editor/Inspector/AvatarParametersEditor.cs
+++ b/Editor/Inspector/AvatarParametersEditor.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -477,3 +479,15 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#else
+
+using UnityEditor;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    [CustomEditor(typeof(ModularAvatarParameters))]
+    internal class AvatarParametersEditor : MAUnsupportedEditorBase { }
+}
+
+#endif

--- a/Editor/Inspector/BlendshapeSyncEditor.cs
+++ b/Editor/Inspector/BlendshapeSyncEditor.cs
@@ -263,7 +263,7 @@ namespace nadena.dev.modular_avatar.core.editor
         {
             if (_window != null) DestroyImmediate(_window);
             _window = ScriptableObject.CreateInstance<BlendshapeSelectWindow>();
-            _window.AvatarRoot = RuntimeUtil.FindAvatarInParents(((ModularAvatarBlendshapeSync) target).transform)
+            _window.AvatarRoot = RuntimeUtil.FindAvatarTransformInParents(((ModularAvatarBlendshapeSync) target).transform)
                 .gameObject;
             _window.OfferBinding += OfferBinding;
             _window.Show();

--- a/Editor/Inspector/BoneProxyEditor.cs
+++ b/Editor/Inspector/BoneProxyEditor.cs
@@ -50,7 +50,7 @@ namespace nadena.dev.modular_avatar.core.editor
             for (int i = 0; i < targets.Length; i++)
             {
                 var t = (ModularAvatarBoneProxy) targets[i];
-                var av = RuntimeUtil.FindAvatarInParents(t.transform);
+                var av = RuntimeUtil.FindAvatarTransformInParents(t.transform);
 
                 if (av != null && parentAvatar == null) parentAvatar = av.gameObject;
                 if (av == null || parentAvatar != av.gameObject)
@@ -91,7 +91,7 @@ namespace nadena.dev.modular_avatar.core.editor
                         var t = (ModularAvatarBoneProxy) targets[i];
                         Undo.RecordObjects(targets, "Set targets");
                         var xform = ((TempObjRef) objRefs[i]).target;
-                        if (RuntimeUtil.FindAvatarInParents(xform)?.gameObject != parentAvatar) continue;
+                        if (RuntimeUtil.FindAvatarTransformInParents(xform)?.gameObject != parentAvatar) continue;
                         t.target = xform;
                     }
                 }

--- a/Editor/Inspector/FirstPersonVisibleEditor.cs
+++ b/Editor/Inspector/FirstPersonVisibleEditor.cs
@@ -10,7 +10,7 @@ namespace nadena.dev.modular_avatar.core.editor
         private void OnEnable()
         {
             var target = (ModularAvatarVisibleHeadAccessory) this.target;
-            var avatar = RuntimeUtil.FindAvatarInParents(target.transform);
+            var avatar = RuntimeUtil.FindAvatarInParents(target.transform).transform;
 
             if (avatar != null) _processor = new VisibleHeadAccessoryProcessor(avatar);
         }

--- a/Editor/Inspector/FirstPersonVisibleEditor.cs
+++ b/Editor/Inspector/FirstPersonVisibleEditor.cs
@@ -10,7 +10,7 @@ namespace nadena.dev.modular_avatar.core.editor
         private void OnEnable()
         {
             var target = (ModularAvatarVisibleHeadAccessory) this.target;
-            var avatar = RuntimeUtil.FindAvatarInParents(target.transform).transform;
+            var avatar = RuntimeUtil.FindAvatarTransformInParents(target.transform);
 
             if (avatar != null) _processor = new VisibleHeadAccessoryProcessor(avatar);
         }

--- a/Editor/Inspector/InspectorCommon.cs
+++ b/Editor/Inspector/InspectorCommon.cs
@@ -1,5 +1,11 @@
 ﻿using UnityEditor;
+
+#if UNITY_2021_2_OR_NEWER
+using UnityEditor.SceneManagement;
+#else
 using UnityEditor.Experimental.SceneManagement;
+#endif
+
 using UnityEngine;
 
 namespace nadena.dev.modular_avatar.core.editor

--- a/Editor/Inspector/InspectorCommon.cs
+++ b/Editor/Inspector/InspectorCommon.cs
@@ -20,7 +20,7 @@ namespace nadena.dev.modular_avatar.core.editor
             var target = targets[0] as Component;
             if (target == null) return;
 
-            if (RuntimeUtil.FindAvatarInParents(target.transform) == null)
+            if (RuntimeUtil.FindAvatarTransformInParents(target.transform) == null)
             {
                 EditorGUILayout.HelpBox(Localization.S("hint.not_in_avatar"), MessageType.Warning);
             }

--- a/Editor/Inspector/MAAssetBundleEditor.cs
+++ b/Editor/Inspector/MAAssetBundleEditor.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.ScriptableObjects;
+#endif
+
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -31,8 +35,10 @@ namespace nadena.dev.modular_avatar.core.editor
             typeof(Mesh),
             typeof(AnimationClip),
             typeof(RuntimeAnimatorController),
+#if MA_VRCSDK3_AVATARS
             typeof(VRCExpressionParameters),
             typeof(VRCExpressionsMenu),
+#endif
         };
 
         private Dictionary<UnityEngine.Object, AssetInfo> _assets;
@@ -60,12 +66,16 @@ namespace nadena.dev.modular_avatar.core.editor
 
             public void PopulateReferences(Dictionary<UnityEngine.Object, AssetInfo> assets)
             {
-                if (Asset is Mesh || Asset is AnimationClip || Asset is VRCExpressionsMenu ||
-                    Asset is VRCExpressionsMenu)
+                if (Asset is Mesh || Asset is AnimationClip)
                 {
                     return; // No child objects
                 }
-
+#if MA_VRCSDK3_AVATARS
+                if (Asset is VRCExpressionsMenu || Asset is VRCExpressionsMenu)
+                {
+                    return; // No child objects
+                }
+#endif
                 var so = new SerializedObject(Asset);
                 var prop = so.GetIterator();
 

--- a/Editor/Inspector/MAEditorBase.cs
+++ b/Editor/Inspector/MAEditorBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 
@@ -79,5 +80,13 @@ namespace nadena.dev.modular_avatar.core.editor
 
     internal class MAVisualElement : VisualElement
     {
+    }
+
+    internal abstract class MAUnsupportedEditorBase : MAEditorBase
+    {
+        protected override void OnInnerInspectorGUI()
+        {
+            EditorGUILayout.HelpBox(Localization.S("unsupported"), MessageType.Error);
+        }
     }
 }

--- a/Editor/Inspector/Menu/AvMenuTreeView.cs
+++ b/Editor/Inspector/Menu/AvMenuTreeView.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -232,3 +234,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/Inspector/Menu/MAMenuItemInspector.cs
+++ b/Editor/Inspector/Menu/MAMenuItemInspector.cs
@@ -1,4 +1,6 @@
-﻿using UnityEditor;
+﻿#if MA_VRCSDK3_AVATARS
+
+using UnityEditor;
 using static nadena.dev.modular_avatar.core.editor.Localization;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -53,3 +55,17 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#else
+
+using UnityEditor;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    [CustomEditor(typeof(ModularAvatarMenuItem))]
+    internal class MAMenuItemInspector : MAUnsupportedEditorBase { }
+    [CustomEditor(typeof(ModularAvatarMenuGroup))]
+    internal class MAMenuGroupInspector : MAUnsupportedEditorBase { }
+}
+
+#endif

--- a/Editor/Inspector/Menu/MenuInstallerEditor.cs
+++ b/Editor/Inspector/Menu/MenuInstallerEditor.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -586,3 +588,15 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#else
+
+using UnityEditor;
+
+namespace nadena.dev.modular_avatar.core.editor
+{
+    [CustomEditor(typeof(ModularAvatarMenuInstaller))]
+    internal class MenuInstallerEditor : MAUnsupportedEditorBase { }
+}
+
+#endif

--- a/Editor/Inspector/Menu/MenuItemGUI.cs
+++ b/Editor/Inspector/Menu/MenuItemGUI.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Linq;
 using System.Runtime.Serialization;
 using nadena.dev.modular_avatar.core.menu;
@@ -489,3 +491,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/Inspector/Menu/MenuPreviewGUI.cs
+++ b/Editor/Inspector/Menu/MenuPreviewGUI.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using nadena.dev.modular_avatar.core.menu;
 using static nadena.dev.modular_avatar.core.editor.Localization;
@@ -274,3 +276,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/Inspector/Menu/ParameterField.cs
+++ b/Editor/Inspector/Menu/ParameterField.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
@@ -284,3 +286,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/Inspector/MeshSettingsEditor.cs
+++ b/Editor/Inspector/MeshSettingsEditor.cs
@@ -41,11 +41,11 @@ namespace nadena.dev.modular_avatar.core.editor
             if (targets.Length == 1)
             {
                 settings = (ModularAvatarMeshSettings) target;
-                var avatar = RuntimeUtil.FindAvatarInParents(settings.transform);
-                if (avatar != null)
+                var avatarTransform = RuntimeUtil.FindAvatarTransformInParents(settings.transform);
+                if (avatarTransform != null)
                 {
                     Component mesh = (Component) target;
-                    merged = MeshSettingsPass.MergeSettings(avatar.transform, mesh.transform);
+                    merged = MeshSettingsPass.MergeSettings(avatarTransform, mesh.transform);
                     haveMerged = true;
                 }
             }

--- a/Editor/Menu/MenuExtractor.cs
+++ b/Editor/Menu/MenuExtractor.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+#if MA_VRCSDK3_AVATARS
+
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
@@ -129,3 +131,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/Menu/VirtualMenu.cs
+++ b/Editor/Menu/VirtualMenu.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -6,6 +8,7 @@ using JetBrains.Annotations;
 using nadena.dev.modular_avatar.core.menu;
 using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEngine;
+
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 
@@ -478,3 +481,5 @@ namespace nadena.dev.modular_avatar.core.editor.menu
         }
     }
 }
+
+#endif

--- a/Editor/MenuInstallHook.cs
+++ b/Editor/MenuInstallHook.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using nadena.dev.modular_avatar.core.editor.menu;
@@ -85,3 +87,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/MergeAnimatorProcessor.cs
+++ b/Editor/MergeAnimatorProcessor.cs
@@ -1,4 +1,6 @@
-﻿/*
+﻿#if MA_VRCSDK3_AVATARS
+
+/*
  * MIT License
  *
  * Copyright (c) 2022 bd_
@@ -248,3 +250,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/MergeArmatureHook.cs
+++ b/Editor/MergeArmatureHook.cs
@@ -30,8 +30,12 @@ using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Animations;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.Dynamics;
 using VRC.SDK3.Dynamics.PhysBone.Components;
+#endif
+
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
@@ -58,6 +62,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
             TopoProcessMergeArmatures(mergeArmatures);
 
+#if MA_VRCSDK3_AVATARS
             foreach (var c in avatarGameObject.transform.GetComponentsInChildren<VRCPhysBone>(true))
             {
                 if (c.rootTransform == null) c.rootTransform = c.transform;
@@ -75,6 +80,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 if (c.rootTransform == null) c.rootTransform = c.transform;
                 RetainBoneReferences(c);
             }
+#endif
 
             foreach (var c in avatarGameObject.transform.GetComponentsInChildren<IConstraint>(true))
             {
@@ -366,6 +372,7 @@ namespace nadena.dev.modular_avatar.core.editor
          */
         private void PruneDuplicatePhysBones()
         {
+#if MA_VRCSDK3_AVATARS
             foreach (var obj in mergedObjects)
             {
                 if (obj.GetComponent<VRCPhysBone>() == null) continue;
@@ -394,6 +401,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     }
                 }
             }
+#endif
         }
     }
 }

--- a/Editor/MeshRetargeter.cs
+++ b/Editor/MeshRetargeter.cs
@@ -180,9 +180,8 @@ namespace nadena.dev.modular_avatar.core.editor
         [CanBeNull]
         public Mesh Retarget()
         {
-            var avatar = RuntimeUtil.FindAvatarInParents(renderer.transform);
-            if (avatar == null) throw new System.Exception("Could not find avatar in parents of " + renderer.name);
-            var avatarTransform = avatar.transform;
+            var avatarTransform = RuntimeUtil.FindAvatarTransformInParents(renderer.transform);
+            if (avatarTransform == null) throw new System.Exception("Could not find avatar in parents of " + renderer.name);
 
             var avPos = avatarTransform.position;
             var avRot = avatarTransform.rotation;

--- a/Editor/MeshSettingsPass.cs
+++ b/Editor/MeshSettingsPass.cs
@@ -22,7 +22,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public void OnPreprocessAvatar()
         {
-            foreach (var mesh in context.AvatarDescriptor.GetComponentsInChildren<Renderer>(true))
+            foreach (var mesh in context.AvatarRootTransform.GetComponentsInChildren<Renderer>(true))
             {
                 ProcessMesh(mesh);
             }
@@ -94,7 +94,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
         private void ProcessMesh(Renderer mesh)
         {
-            MergedSettings settings = MergeSettings(context.AvatarDescriptor.transform, mesh.transform);
+            MergedSettings settings = MergeSettings(context.AvatarRootTransform, mesh.transform);
 
             if (settings.SetAnchor)
             {

--- a/Editor/OptimizationPasses/GCGameObjectsPass.cs
+++ b/Editor/OptimizationPasses/GCGameObjectsPass.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Dynamics.PhysBone.Components;
+#endif
 
 namespace nadena.dev.modular_avatar.core.editor
 {
@@ -56,10 +59,12 @@ namespace nadena.dev.modular_avatar.core.editor
                     {
                         case Transform t: break;
 
+#if MA_VRCSDK3_AVATARS
                         case VRCPhysBone pb:
                             MarkObject(obj);
                             MarkPhysBone(pb);
                             break;
+#endif
 
                         case AvatarTagComponent _:
                             // Tag components will not be retained at runtime, so pretend they're not there.
@@ -123,6 +128,7 @@ namespace nadena.dev.modular_avatar.core.editor
             }
         }
 
+#if MA_VRCSDK3_AVATARS
         private void MarkPhysBone(VRCPhysBone pb)
         {
             var rootTransform = pb.GetRootTransform();
@@ -137,6 +143,7 @@ namespace nadena.dev.modular_avatar.core.editor
             // Mark colliders, etc
             MarkAllReferencedObjects(pb);
         }
+#endif
 
         private void MarkAllReferencedObjects(Component component)
         {

--- a/Editor/ParameterPolicy.cs
+++ b/Editor/ParameterPolicy.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using UnityEditor.Animations;
@@ -318,3 +320,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/PhysboneBlockerPass.cs
+++ b/Editor/PhysboneBlockerPass.cs
@@ -1,18 +1,20 @@
-﻿/*
+﻿#if MA_VRCSDK3_AVATARS
+
+/*
  * MIT License
- * 
+ *
  * Copyright (c) 2022 bd_
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -76,3 +78,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/PluginDefinition/ModularAvatarContext.cs
+++ b/Editor/PluginDefinition/ModularAvatarContext.cs
@@ -16,7 +16,7 @@ namespace nadena.dev.modular_avatar.core.editor
                 BuildContext = new BuildContext(context);
             }
 
-            toDispose = BuildReport.CurrentReport.ReportingOnAvatar(context.AvatarDescriptor);
+            toDispose = BuildReport.CurrentReport.ReportingOnAvatar(context);
         }
 
         public void OnDeactivate(ndmf.BuildContext context)

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -146,7 +146,9 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+#if MA_VRCSDK3_AVATARS
             new RenameParametersHook().OnPreprocessAvatar(context.AvatarRootObject, MAContext(context));
+#endif
         }
     }
 
@@ -154,7 +156,9 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+#if MA_VRCSDK3_AVATARS
             new MergeAnimatorProcessor().OnPreprocessAvatar(context.AvatarRootObject, MAContext(context));
+#endif
         }
     }
 
@@ -162,7 +166,9 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+#if MA_VRCSDK3_AVATARS
             new MenuInstallHook().OnPreprocessAvatar(context.AvatarRootObject, MAContext(context));
+#endif
         }
     }
 
@@ -202,7 +208,9 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+#if MA_VRCSDK3_AVATARS
             new BlendshapeSyncAnimationProcessor().OnPreprocessAvatar(context.AvatarRootObject, MAContext(context));
+#endif
         }
     }
 
@@ -210,7 +218,9 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
     {
         protected override void Execute(ndmf.BuildContext context)
         {
+#if MA_VRCSDK3_AVATARS
             PhysboneBlockerPass.Process(context.AvatarRootObject);
+#endif
         }
     }
 

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -42,7 +42,7 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
                     seq.Run(BoneProxyPluginPass.Instance);
                     seq.Run(VisibleHeadAccessoryPluginPass.Instance);
                     seq.Run("World Fixed Object",
-                        ctx => new WorldFixedObjectProcessor(ctx.AvatarDescriptor).Process(ctx)
+                        ctx => new WorldFixedObjectProcessor(ctx).Process(ctx)
                     );
                     seq.Run(ReplaceObjectPluginPass.Instance);
                     seq.Run(BlendshapeSyncAnimationPluginPass.Instance);
@@ -186,7 +186,7 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
     {
         protected override void Execute(ndmf.BuildContext context)
         {
-            new VisibleHeadAccessoryProcessor(context.AvatarDescriptor).Process(MAContext(context));
+            new VisibleHeadAccessoryProcessor(context.AvatarRootTransform).Process(MAContext(context));
         }
     }
 

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -50,8 +50,10 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
                 seq.Run(PhysbonesBlockerPluginPass.Instance);
                 seq.Run("Fixup Expressions Menu", ctx =>
                 {
+#if MA_VRCSDK3_AVATARS
                     var maContext = ctx.Extension<ModularAvatarContext>().BuildContext;
                     FixupExpressionsMenuPass.FixupExpressionsMenu(maContext);
+#endif
                 });
                 seq.Run("Rebind humanoid avatar", ctx =>
                 {

--- a/Editor/PluginDefinition/PluginDefinition.cs
+++ b/Editor/PluginDefinition/PluginDefinition.cs
@@ -26,7 +26,9 @@ namespace nadena.dev.modular_avatar.core.editor.plugin
             Sequence seq = InPhase(BuildPhase.Resolving);
             seq.Run(ResolveObjectReferences.Instance);
             // Protect against accidental destructive edits by cloning the input controllers ASAP
+#if MA_VRCSDK3_AVATARS
             seq.Run("Clone animators", AnimationUtil.CloneAllControllers);
+#endif
 
             seq = InPhase(BuildPhase.Transforming);
             seq.WithRequiredExtension(typeof(ModularAvatarContext), _s1 =>

--- a/Editor/PreventStripTagObjects.cs
+++ b/Editor/PreventStripTagObjects.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -64,3 +66,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/RenameParametersHook.cs
+++ b/Editor/RenameParametersHook.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if MA_VRCSDK3_AVATARS
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -494,3 +496,5 @@ namespace nadena.dev.modular_avatar.core.editor
         }
     }
 }
+
+#endif

--- a/Editor/ReplaceObjectPass.cs
+++ b/Editor/ReplaceObjectPass.cs
@@ -29,7 +29,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
         public void Process()
         {
-            var avatarDescriptor = _buildContext.AvatarDescriptor;
+            var avatarDescriptor = _buildContext.AvatarRootTransform;
             var replacementComponents =
                 avatarDescriptor.GetComponentsInChildren<ModularAvatarReplaceObject>(true);
 
@@ -43,7 +43,7 @@ namespace nadena.dev.modular_avatar.core.editor
 
             foreach (var component in replacementComponents)
             {
-                var targetObject = component.targetObject?.Get(_buildContext.AvatarDescriptor);
+                var targetObject = component.targetObject?.Get(_buildContext.AvatarRootTransform);
 
                 if (targetObject == null)
                 {
@@ -154,7 +154,7 @@ namespace nadena.dev.modular_avatar.core.editor
         {
             Dictionary<UnityObject, List<Reference>> refIndex = new Dictionary<UnityObject, List<Reference>>();
 
-            IndexObject(_buildContext.AvatarDescriptor.gameObject);
+            IndexObject(_buildContext.AvatarRootObject);
 
             return refIndex;
 

--- a/Editor/Util.cs
+++ b/Editor/Util.cs
@@ -29,12 +29,15 @@ using JetBrains.Annotations;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
-using VRC.SDK3.Avatars.Components;
+#if MA_VRCSDK3_AVATARS
 using VRC.SDKBase.Editor.BuildPipeline;
+#endif
 using Object = UnityEngine.Object;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
+
+#if MA_VRCSDK3_AVATARS
     internal class CleanupTempAssets : IVRCSDKPostprocessAvatarCallback
     {
         public int callbackOrder => 99999;
@@ -44,6 +47,7 @@ namespace nadena.dev.modular_avatar.core.editor
             Util.DeleteTemporaryAssets();
         }
     }
+#endif
 
     [InitializeOnLoad]
     internal static class Util
@@ -238,7 +242,7 @@ namespace nadena.dev.modular_avatar.core.editor
             {
                 var component = ptr.GetComponent<T>();
                 if (component != null) yield return component;
-                if (ptr.GetComponent<VRCAvatarDescriptor>() != null) break;
+                if (RuntimeUtil.IsAvatarRoot(ptr)) break;
                 ptr = ptr.parent;
             }
         }

--- a/Editor/VisibleHeadAccessoryProcessor.cs
+++ b/Editor/VisibleHeadAccessoryProcessor.cs
@@ -2,8 +2,11 @@
 using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEngine;
 using UnityEngine.Animations;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Dynamics.PhysBone.Components;
+#endif
 
 namespace nadena.dev.modular_avatar.core.editor
 {
@@ -19,20 +22,21 @@ namespace nadena.dev.modular_avatar.core.editor
             InPhysBoneChain
         }
 
-        private VRCAvatarDescriptor _avatar;
+        private Transform _avatar;
         private HashSet<Transform> _activeBones = new HashSet<Transform>();
         private Transform _headBone;
 
         private HashSet<Transform> _visibleBones = new HashSet<Transform>();
         private Transform _proxyHead;
 
-        public VisibleHeadAccessoryProcessor(VRCAvatarDescriptor avatar)
+        public VisibleHeadAccessoryProcessor(Transform avatar)
         {
             _avatar = avatar;
 
             var animator = avatar.GetComponent<Animator>();
             _headBone = animator != null ? animator.GetBoneTransform(HumanBodyBones.Head) : null;
 
+#if MA_VRCSDK3_AVATARS
             foreach (var physBone in avatar.GetComponentsInChildren<VRCPhysBone>(true))
             {
                 var boneRoot = physBone.rootTransform != null ? physBone.rootTransform : physBone.transform;
@@ -43,6 +47,7 @@ namespace nadena.dev.modular_avatar.core.editor
                     Traverse(child, ignored);
                 }
             }
+#endif
 
             void Traverse(Transform bone, HashSet<Transform> ignored)
             {
@@ -60,6 +65,7 @@ namespace nadena.dev.modular_avatar.core.editor
         {
             bool didWork = false;
 
+#if MA_VRCSDK3_AVATARS
             foreach (var target in _avatar.GetComponentsInChildren<ModularAvatarVisibleHeadAccessory>(true))
             {
                 var w = BuildReport.ReportingObject(target, () => Process(target));
@@ -75,6 +81,7 @@ namespace nadena.dev.modular_avatar.core.editor
                         () => new VisibleHeadAccessoryMeshProcessor(smr, _visibleBones, _proxyHead).Retarget(context));
                 }
             }
+#endif
         }
 
         bool Process(ModularAvatarVisibleHeadAccessory target)

--- a/Editor/WorldFixedObjectProcessor.cs
+++ b/Editor/WorldFixedObjectProcessor.cs
@@ -3,17 +3,16 @@ using nadena.dev.modular_avatar.editor.ErrorReporting;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Animations;
-using VRC.SDK3.Avatars.Components;
 
 namespace nadena.dev.modular_avatar.core.editor
 {
     internal class WorldFixedObjectProcessor
     {
         private BuildContext _context;
-        private VRCAvatarDescriptor _avatar;
+        private ndmf.BuildContext _avatar;
         private Transform _proxy;
 
-        public WorldFixedObjectProcessor(VRCAvatarDescriptor avatar)
+        public WorldFixedObjectProcessor(ndmf.BuildContext avatar)
         {
             _avatar = avatar;
         }
@@ -21,7 +20,7 @@ namespace nadena.dev.modular_avatar.core.editor
         public void Process(BuildContext context)
         {
             _context = context;
-            foreach (var target in _avatar.GetComponentsInChildren<ModularAvatarWorldFixedObject>(true)
+            foreach (var target in _avatar.AvatarRootObject.GetComponentsInChildren<ModularAvatarWorldFixedObject>(true)
                          .OrderByDescending(x => NestCount(x.transform)))
                 BuildReport.ReportingObject(target, () => Process(target));
         }
@@ -66,7 +65,7 @@ namespace nadena.dev.modular_avatar.core.editor
             var fixedGameObject = AssetDatabase.LoadAssetAtPath<GameObject>(
                 AssetDatabase.GUIDToAssetPath("78828bfbcb4cb4ce3b00de044eb2d927"));
 
-            var avatarRoot = _avatar.transform;
+            var avatarRoot = _avatar.AvatarRootTransform;
             GameObject obj = new GameObject("(MA WorldFixedRoot)");
 
             obj.transform.SetParent(avatarRoot, false);

--- a/Editor/nadena.dev.modular-avatar.core.editor.asmdef
+++ b/Editor/nadena.dev.modular-avatar.core.editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "nadena.dev.modular-avatar.core.editor",
+    "rootNamespace": "",
     "references": [
         "GUID:fc900867c0f47cd49b6e2ae4ef907300",
         "GUID:5718fb738711cd34ea54e9553040911d",
@@ -33,6 +34,11 @@
             "name": "com.anatawa12.avatar-optimizer",
             "expression": "(,1.5.0-rc.8)",
             "define": "LEGACY_AVATAR_OPTIMIZER"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "MA_VRCSDK3_AVATARS"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Activator.cs
+++ b/Runtime/Activator.cs
@@ -1,7 +1,10 @@
 ﻿#if UNITY_EDITOR
 
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDKBase;
+#endif
 
 namespace nadena.dev.modular_avatar.core
 {

--- a/Runtime/AvatarObjectReference.cs
+++ b/Runtime/AvatarObjectReference.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using UnityEngine;
-using VRC.SDK3.Avatars.Components;
 
 namespace nadena.dev.modular_avatar.core
 {
@@ -72,7 +71,7 @@ namespace nadena.dev.modular_avatar.core
             {
                 referencePath = "";
             }
-            else if (target.GetComponent<VRCAvatarDescriptor>() != null)
+            else if (RuntimeUtil.IsAvatarRoot(target.transform))
             {
                 referencePath = AVATAR_ROOT;
             }

--- a/Runtime/AvatarObjectReference.cs
+++ b/Runtime/AvatarObjectReference.cs
@@ -33,16 +33,16 @@ namespace nadena.dev.modular_avatar.core
             RuntimeUtil.OnHierarchyChanged -= InvalidateCache;
             RuntimeUtil.OnHierarchyChanged += InvalidateCache;
 
-            var avatar = RuntimeUtil.FindAvatarInParents(container.transform);
-            if (avatar == null) return (_cachedReference = null);
+            var avatarTransform = RuntimeUtil.FindAvatarTransformInParents(container.transform);
+            if (avatarTransform == null) return (_cachedReference = null);
 
             if (referencePath == AVATAR_ROOT)
             {
-                _cachedReference = avatar.gameObject;
+                _cachedReference = avatarTransform.gameObject;
                 return _cachedReference;
             }
 
-            _cachedReference = avatar.transform.Find(referencePath)?.gameObject;
+            _cachedReference = avatarTransform.Find(referencePath)?.gameObject;
             if (_cachedReference == null) return null;
             
             // https://github.com/bdunderscore/modular-avatar/issues/308

--- a/Runtime/AvatarTagComponent.cs
+++ b/Runtime/AvatarTagComponent.cs
@@ -24,10 +24,22 @@
 
 using System;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDKBase;
+#endif
 
 namespace nadena.dev.modular_avatar.core
 {
+    
+#if !MA_VRCSDK3_AVATARS
+
+    interface IEditorOnly
+    {
+    }
+
+#endif
+
     /**
      * This abstract base class is injected into the VRCSDK avatar component allowlist to avoid
      */

--- a/Runtime/MAMoveIndependently.cs
+++ b/Runtime/MAMoveIndependently.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using nadena.dev.modular_avatar.core.armature_lock;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDKBase;
+#endif
 
 namespace nadena.dev.modular_avatar.core.ArmatureAwase
 {

--- a/Runtime/Menu/ModularAvatarMenuGroup.cs
+++ b/Runtime/Menu/ModularAvatarMenuGroup.cs
@@ -10,7 +10,10 @@ namespace nadena.dev.modular_avatar.core
 
         public override void Visit(NodeContext context)
         {
+#if MA_VRCSDK3_AVATARS
+
             context.PushNode(new MenuNodesUnder(targetObject != null ? targetObject : gameObject));
+#endif
         }
 
         public override void ResolveReferences()
@@ -19,3 +22,4 @@ namespace nadena.dev.modular_avatar.core
         }
     }
 }
+

--- a/Runtime/Menu/ModularAvatarMenuGroup.cs
+++ b/Runtime/Menu/ModularAvatarMenuGroup.cs
@@ -3,7 +3,11 @@ using UnityEngine;
 
 namespace nadena.dev.modular_avatar.core
 {
+#if MA_VRCSDK3_AVATARS
     [AddComponentMenu("Modular Avatar/MA Menu Group")]
+#else
+    [AddComponentMenu("Modular Avatar/Unsupported/MA Menu Group (Unsupported)")]
+#endif
     public class ModularAvatarMenuGroup : MenuSourceComponent
     {
         public GameObject targetObject;

--- a/Runtime/Menu/ModularAvatarMenuInstaller.cs
+++ b/Runtime/Menu/ModularAvatarMenuInstaller.cs
@@ -6,7 +6,11 @@ using VRC.SDK3.Avatars.ScriptableObjects;
 
 namespace nadena.dev.modular_avatar.core
 {
+#if MA_VRCSDK3_AVATARS
     [AddComponentMenu("Modular Avatar/MA Menu Installer")]
+#else
+    [AddComponentMenu("Modular Avatar/Unsupported/MA Menu Installer (Unsupported)")]
+#endif
     public class ModularAvatarMenuInstaller : AvatarTagComponent
     {
 #if MA_VRCSDK3_AVATARS

--- a/Runtime/Menu/ModularAvatarMenuInstaller.cs
+++ b/Runtime/Menu/ModularAvatarMenuInstaller.cs
@@ -1,14 +1,21 @@
 ﻿using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.ScriptableObjects;
+#endif
 
 namespace nadena.dev.modular_avatar.core
 {
     [AddComponentMenu("Modular Avatar/MA Menu Installer")]
     public class ModularAvatarMenuInstaller : AvatarTagComponent
     {
+#if MA_VRCSDK3_AVATARS
         public VRCExpressionsMenu menuToAppend;
         public VRCExpressionsMenu installTargetMenu;
-
+#else
+        public ScriptableObject menuToAppend;
+        public ScriptableObject installTargetMenu;
+#endif
 
         // ReSharper disable once Unity.RedundantEventFunction
         void Start()

--- a/Runtime/Menu/VirtualMenuAPI.cs
+++ b/Runtime/Menu/VirtualMenuAPI.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.ScriptableObjects;
+#endif
 
 // Internal runtime API for the Virtual Menu system.
 //
@@ -10,6 +13,9 @@ using VRC.SDK3.Avatars.ScriptableObjects;
 // here public, but be aware that they may change without warning in the future.
 namespace nadena.dev.modular_avatar.core.menu
 {
+
+#if MA_VRCSDK3_AVATARS
+
     /// <summary>
     /// A MenuNode represents a single VRCExpressionsMenu, prior to overflow splitting. MenuNodes form a directed graph,
     /// which may contain cycles, and may include contributions from multiple MenuInstallers, or from the base avatar
@@ -59,6 +65,8 @@ namespace nadena.dev.modular_avatar.core.menu
         }
     }
 
+#endif
+
     /// <summary>
     /// Helper MenuSource which includes all children of a given GameObject containing MenuSourceComponents as menu
     /// items. Implements equality based on the GameObject in question.
@@ -101,12 +109,17 @@ namespace nadena.dev.modular_avatar.core.menu
     /// </summary>
     public interface NodeContext
     {
+        
+#if MA_VRCSDK3_AVATARS
+        
         /// <summary>
         /// Pushes the contents of this expressions menu asset onto the current menu node, handling loops and menu
         /// installer invocations.
         /// </summary>
         /// <param name="expMenu"></param>
         void PushMenuContents(VRCExpressionsMenu expMenu);
+
+#endif
 
         /// <summary>
         /// Pushes the contents of this menu source onto the current menu node.
@@ -119,6 +132,8 @@ namespace nadena.dev.modular_avatar.core.menu
         /// </summary>
         /// <param name="installer"></param>
         void PushNode(ModularAvatarMenuInstaller installer);
+
+#if MA_VRCSDK3_AVATARS
 
         /// <summary>
         /// Pushes a single expressions menu control onto the current menu node. Converts submenus into menu nodes
@@ -147,7 +162,11 @@ namespace nadena.dev.modular_avatar.core.menu
         /// <param name="menu"></param>
         /// <returns></returns>
         VirtualMenuNode NodeFor(MenuSource menu);
+
+#endif
+
     }
+
 
     /// <summary>
     /// An object which can contribute controls to a menu.
@@ -169,7 +188,6 @@ namespace nadena.dev.modular_avatar.core.menu
 
             RuntimeUtil.InvalidateMenu();
         }
-
         public abstract void Visit(NodeContext context);
     }
 }

--- a/Runtime/ModularAvatarBoneProxy.cs
+++ b/Runtime/ModularAvatarBoneProxy.cs
@@ -160,20 +160,20 @@ namespace nadena.dev.modular_avatar.core
                 return null;
             }
 
-            var avatar = RuntimeUtil.FindAvatarInParents(transform);
-            if (avatar == null) return null;
+            var avatarTransform = RuntimeUtil.FindAvatarTransformInParents(transform);
+            if (avatarTransform == null) return null;
 
             if (subPath == "$$AVATAR")
             {
-                return avatar.transform;
+                return avatarTransform;
             }
 
             if (boneReference == HumanBodyBones.LastBone)
             {
-                return avatar.transform.Find(subPath);
+                return avatarTransform.Find(subPath);
             }
 
-            var animator = avatar.GetComponent<Animator>();
+            var animator = avatarTransform.GetComponent<Animator>();
             if (animator == null) return null;
             var bone = animator.GetBoneTransform(boneReference);
             if (bone == null) return null;
@@ -183,9 +183,9 @@ namespace nadena.dev.modular_avatar.core
 
         private void UpdateStaticMapping(Transform newTarget)
         {
-            var avatar = RuntimeUtil.FindAvatarInParents(transform);
+            var avatarTransform = RuntimeUtil.FindAvatarTransformInParents(transform);
             var humanBones = new Dictionary<Transform, HumanBodyBones>();
-            var animator = avatar.GetComponent<Animator>();
+            var animator = avatarTransform.GetComponent<Animator>();
             if (animator == null)
             {
                 return;
@@ -200,7 +200,6 @@ namespace nadena.dev.modular_avatar.core
             }
 
             Transform iter = newTarget;
-            Transform avatarTransform = avatar.transform;
 
             if (newTarget == avatarTransform)
             {

--- a/Runtime/ModularAvatarMenuInstallTarget.cs
+++ b/Runtime/ModularAvatarMenuInstallTarget.cs
@@ -13,7 +13,11 @@ namespace nadena.dev.modular_avatar.core
     ///
     /// We can also end up with a loop between install targets; in this case, we break the loop at an arbitrary point.
     /// </summary>
+#if MA_VRCSDK3_AVATARS
     [AddComponentMenu("Modular Avatar/MA Menu Install Target")]
+#else
+    [AddComponentMenu("Modular Avatar/Unsupported/MA Menu Install Target (Unsupported)")]
+#endif
     internal class ModularAvatarMenuInstallTarget : MenuSourceComponent
     {
         public ModularAvatarMenuInstaller installer;

--- a/Runtime/ModularAvatarMenuItem.cs
+++ b/Runtime/ModularAvatarMenuItem.cs
@@ -1,4 +1,6 @@
-﻿using nadena.dev.modular_avatar.core.menu;
+#if MA_VRCSDK3_AVATARS
+
+using nadena.dev.modular_avatar.core.menu;
 using UnityEngine;
 using VRC.SDK3.Avatars.ScriptableObjects;
 
@@ -76,3 +78,5 @@ namespace nadena.dev.modular_avatar.core
         }
     }
 }
+
+#endif

--- a/Runtime/ModularAvatarMenuItem.cs
+++ b/Runtime/ModularAvatarMenuItem.cs
@@ -13,7 +13,11 @@ namespace nadena.dev.modular_avatar.core
         Children,
     }
 
+#if MA_VRCSDK3_AVATARS
     [AddComponentMenu("Modular Avatar/MA Menu Item")]
+#else
+    [AddComponentMenu("Modular Avatar/Unsupported/MA Menu Item (Unsupported)")]
+#endif
     public class ModularAvatarMenuItem : AvatarTagComponent, MenuSource
     {
 #if MA_VRCSDK3_AVATARS

--- a/Runtime/ModularAvatarMenuItem.cs
+++ b/Runtime/ModularAvatarMenuItem.cs
@@ -1,8 +1,9 @@
-#if MA_VRCSDK3_AVATARS
-
 using nadena.dev.modular_avatar.core.menu;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.ScriptableObjects;
+#endif
 
 namespace nadena.dev.modular_avatar.core
 {
@@ -15,7 +16,9 @@ namespace nadena.dev.modular_avatar.core
     [AddComponentMenu("Modular Avatar/MA Menu Item")]
     public class ModularAvatarMenuItem : AvatarTagComponent, MenuSource
     {
+#if MA_VRCSDK3_AVATARS
         public VRCExpressionsMenu.Control Control;
+#endif
         public SubmenuSource MenuSource;
 
         public GameObject menuSource_otherObjectChildren;
@@ -26,6 +29,8 @@ namespace nadena.dev.modular_avatar.core
         public bool isSynced = true;
 
         public bool isSaved = true;
+
+#if MA_VRCSDK3_AVATARS
 
         protected override void OnValidate()
         {
@@ -43,9 +48,11 @@ namespace nadena.dev.modular_avatar.core
         {
             // no-op
         }
+#endif
 
         public void Visit(NodeContext context)
         {
+#if MA_VRCSDK3_AVATARS
             if (Control == null)
             {
                 Control = new VRCExpressionsMenu.Control();
@@ -75,8 +82,8 @@ namespace nadena.dev.modular_avatar.core
             }
 
             context.PushControl(cloned);
+#endif
         }
     }
 }
 
-#endif

--- a/Runtime/ModularAvatarMergeAnimator.cs
+++ b/Runtime/ModularAvatarMergeAnimator.cs
@@ -36,7 +36,11 @@ namespace nadena.dev.modular_avatar.core
         Absolute
     }
 
+#if MA_VRCSDK3_AVATARS
     [AddComponentMenu("Modular Avatar/MA Merge Animator")]
+#else
+    [AddComponentMenu("Modular Avatar/Unsupported/MA Merge Animator (Unsupported)")]
+#endif
     public class ModularAvatarMergeAnimator : AvatarTagComponent
     {
         public RuntimeAnimatorController animator;

--- a/Runtime/ModularAvatarMergeAnimator.cs
+++ b/Runtime/ModularAvatarMergeAnimator.cs
@@ -23,7 +23,10 @@
  */
 
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
+#endif
 
 namespace nadena.dev.modular_avatar.core
 {
@@ -37,7 +40,13 @@ namespace nadena.dev.modular_avatar.core
     public class ModularAvatarMergeAnimator : AvatarTagComponent
     {
         public RuntimeAnimatorController animator;
+
+#if MA_VRCSDK3_AVATARS
         public VRCAvatarDescriptor.AnimLayerType layerType = VRCAvatarDescriptor.AnimLayerType.FX;
+#else
+        public int layerType;
+#endif
+
         public bool deleteAttachedAnimator;
         public MergeAnimatorPathMode pathMode = MergeAnimatorPathMode.Relative;
         public bool matchAvatarWriteDefaults;

--- a/Runtime/ModularAvatarMergeArmature.cs
+++ b/Runtime/ModularAvatarMergeArmature.cs
@@ -160,7 +160,7 @@ namespace nadena.dev.modular_avatar.core
         public void InferPrefixSuffix()
         {
             // We only infer if targeting the armature (below the Hips bone)
-            var rootAnimator = RuntimeUtil.FindAvatarInParents(transform)?.GetComponent<Animator>();
+            var rootAnimator = RuntimeUtil.FindAvatarTransformInParents(transform)?.GetComponent<Animator>();
             if (rootAnimator == null) return;
 
             var hips = rootAnimator.GetBoneTransform(HumanBodyBones.Hips);

--- a/Runtime/ModularAvatarPBBlocker.cs
+++ b/Runtime/ModularAvatarPBBlocker.cs
@@ -27,7 +27,11 @@ using UnityEngine;
 namespace nadena.dev.modular_avatar.core
 {
     [DisallowMultipleComponent]
+#if MA_VRCSDK3_AVATARS
     [AddComponentMenu("Modular Avatar/MA PhysBone Blocker")]
+#else
+    [AddComponentMenu("Modular Avatar/Unsupported/MA PhysBone Blocker (Unsupported)")]
+#endif
     public class ModularAvatarPBBlocker : AvatarTagComponent
     {
         public override void ResolveReferences()

--- a/Runtime/ModularAvatarParameters.cs
+++ b/Runtime/ModularAvatarParameters.cs
@@ -29,7 +29,11 @@ namespace nadena.dev.modular_avatar.core
     }
 
     [DisallowMultipleComponent]
+#if MA_VRCSDK3_AVATARS
     [AddComponentMenu("Modular Avatar/MA Parameters")]
+#else
+    [AddComponentMenu("Modular Avatar/Unsupported/MA Parameters (Unsupported)")]
+#endif
     public class ModularAvatarParameters : AvatarTagComponent
     {
         public List<ParameterConfig> parameters = new List<ParameterConfig>();

--- a/Runtime/RuntimeUtil.cs
+++ b/Runtime/RuntimeUtil.cs
@@ -26,10 +26,15 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using UnityEngine;
+
+#if MA_VRCSDK3_AVATARS
 using VRC.SDK3.Avatars.Components;
+#endif
+
 #if UNITY_EDITOR
 using System.Reflection;
 #endif
+
 
 namespace nadena.dev.modular_avatar.core
 {
@@ -87,6 +92,9 @@ namespace nadena.dev.modular_avatar.core
             return RelativePath(avatar.gameObject, child);
         }
 
+        public static bool IsAvatarRoot(Transform target) => ndmf.runtime.RuntimeUtil.IsAvatarRoot(target);
+
+#if MA_VRCSDK3_AVATARS
         public static VRCAvatarDescriptor FindAvatarInParents(Transform target)
         {
             while (target != null)
@@ -98,6 +106,9 @@ namespace nadena.dev.modular_avatar.core
 
             return null;
         }
+#endif
+
+        public static Transform FindAvatarTransformInParents(Transform target) => ndmf.runtime.RuntimeUtil.FindAvatarInParents(target);
 
         public static void MarkDirty(UnityEngine.Object obj)
         {

--- a/Runtime/RuntimeUtil.cs
+++ b/Runtime/RuntimeUtil.cs
@@ -87,7 +87,7 @@ namespace nadena.dev.modular_avatar.core
         public static string AvatarRootPath(GameObject child)
         {
             if (child == null) return null;
-            var avatar = FindAvatarInParents(child.transform);
+            var avatar = FindAvatarTransformInParents(child.transform);
             if (avatar == null) return null;
             return RelativePath(avatar.gameObject, child);
         }
@@ -95,6 +95,7 @@ namespace nadena.dev.modular_avatar.core
         public static bool IsAvatarRoot(Transform target) => ndmf.runtime.RuntimeUtil.IsAvatarRoot(target);
 
 #if MA_VRCSDK3_AVATARS
+        [Obsolete("Please use RuntimeUtil.FindAvatarTransformInParents()")]
         public static VRCAvatarDescriptor FindAvatarInParents(Transform target)
         {
             while (target != null)

--- a/Runtime/nadena.dev.modular-avatar.core.asmdef
+++ b/Runtime/nadena.dev.modular-avatar.core.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "nadena.dev.modular-avatar.core",
     "references": [
-        "GUID:2665a8d13d1b3f18800f46e256720795"
+        "GUID:2665a8d13d1b3f18800f46e256720795",
+        "GUID:fe747755f7b44e048820525b07f9b956"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -16,6 +17,12 @@
     ],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "MA_VRCSDK3_AVATARS"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
このPRに関する議論はこちらのDiscussionsへお願いします: https://github.com/bdunderscore/modular-avatar/discussions/467

--- 

#1 の続編。

（これは本家がVRCSDKへの依存性を解消するまでの間メンテされるパッチです）

## 単にVRMでもModular Avatarを使いたい人向け

VRCSDKを入れなくてもModular AvatarとAAOが使えます。
Modular Avatar 1.8.0 と Avatar Optimizer 1.5.1 （いずれも予定／このバージョン番号は予告なく変更されます）をベースに改変されています。

一部の機能は動きません。一部のコンポーネントはVRCSDKが入ってないプロジェクトで使うと設定内容が破壊され、VRCSDKが入っているプロジェクトに戻しても復元されません。
VRCSDKが入っていないために使えないコンポーネントは名前に (Unsupported) がつきます。主にPhysBone系とかMenu系がそうなります。

### インストール

自明な理由から、このModular AvatarのforkはOpenUPMなどのUPMリポジトリに登録されていません。
これを読んでいるということはVCC/VPMは利用できないはずなので、代わりにUPMのGit依存性でインストールします。
JSONファイルを編集する場合は、適当なテキストエディタで.jsonファイルを開いてください。

1. Gitが必要になりますので、インストールされていない場合はGitをインストールしてください。
1. Modular Avatarをインストールしたいプロジェクトの `Packages/manifest.json` に以下の項目を足してください。（カンマはいい感じに補ってください）

```
"com.anatawa12.avatar-optimizer": "https://github.com/kaikoga/AvatarOptimizer.git#vista",
"com.anatawa12.custom-localization-for-editor-extension": "https://github.com/anatawa12/CustomLocalization4EditorExtension.git#v1.1.0",
"nadena.dev.modular-avatar": "https://github.com/kaikoga/modular-avatar.git#vista",
"nadena.dev.ndmf": "https://github.com/bdunderscore/ndmf.git#1.2.1",
"net.kaikoga.ndmf-deps": "https://github.com/kaikoga/ndmf-deps.git#main",
```

#### 空のプロジェクトにインストールする場合の手順

#### VRCSDKと一緒に本forkを使う場合の手順

- `"net.kaikoga.ndmf-deps"` の行はVRCSDKが入っているプロジェクトでは入れないでください（VRCSDKが入ってる場合は上から４行だけ使います）
- VCCでインポートしたModular Avatar / Avatar Optimizerが優先されます。本forkを利用する場合、VCC側のModular Avatar / Avatar Optimizerは外してください。

#### VRCSDK＋本家MA+本家AOをセットアップしたアバタープロジェクトからVRCSDKを抜く場合の手順

- `Packages/vpm-manifest.json` と、VCCで`Packages` 以下に追加されたVPMパッケージを手動で削除してください。
- 「Project Settings」の「Script Define Symbols」に `VRC_SDK_VRCSDK3` が設定されているはずですが、これが入っていると動かないツールがある（lilToonなど）ので削除することをお勧めします。

### アップデート

`Packages/package-lock.json` を削除すると、Git依存性でインポートされたUPMパッケージの最新版が再インポートされます。
確率は低いですが、Git依存性でインポートされたUPMパッケージが他にもある場合、Gitプロジェクトが壊れることがあるので気をつけてください。

### ハマリどころ

- VRM0のMetaは素体に刺してもたぶん大丈夫です。
- VRM1のVRMInstanceは素体に刺してもたぶん大丈夫ですが、その場合はVRM1のHumanoidも一緒に刺してください。
- AAOのTrace And Optimizeを使うとVRM0のBlendShapeProxy / VRM1のExpressionは死にます。（BlendShapeをインデックス管理してるため）
  AAOがVRMに対応するまでは、表情に使うSkinnedMeshRendererのBlendShapeは最適化しないようにしてください。
- VRM0 / VRM1のFirstPersonは壊れるのでBake後に刺すか、Renderersを空にしてください。
  - つまり合成前にVRM0のFirst Person Offset ( = View Position) を指定することはできません。運用でカバーしてください。
- Spring Boneの合成や最適化は特に何もしていないので、使えたらラッキーと思ってください。（素体側に刺しておけば大丈夫な気がします）
- VRMで使う場合、 (Unsupported) ってついてない MA / AAO の一部コンポーネントも動きません。Constraintを使う系はダメです。

## 技術的詳細

DLLへの依存性はndmf-depsに切り出しました。

### ndmf の改変

- MAやAAOからVRCAvatarDescriptorを取り除く対応に伴い、いくつかのユーティリティメソッドを RuntimeUtil 経由で公開しています。

### MA の改変（ AAO も方針は一緒）

- VRCSDKがインストールされているときだけ Version Defines の仕組みで `MA_VRCSDK3_AVATARS` コンパイルフラグ（lilToonに命名規則を合わせました）がセットされます
- アバターへの参照をVRCAvatarDescriptorで表現している箇所は、ndmfのBuildContextかAnimatorかTransformのうち、いずれか動く方に置き換えました
  - Transformで取り回すよりはAvatarReference型をndmfで定義してラップしたほうがいい気もしています
- アバターへの参照 **以外** のVRCSDKへの依存を `MA_VRCSDK3_AVATARS` で囲います
  - （VRCSDKによって）VRCプロジェクトではScripting Define Symbolsに設定されているはずの `VRC_SDK_VRCSDK3` は参照しません。
- Runtimeではコンポーネントは残りますが、VRCのデータ型に依存した設定項目は消えます
- EditorではVRC依存の解消が難しいパスやインスペクタは削除しています
